### PR TITLE
Cloudflare Pages互換性の設定を追加

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,17 @@ const nextConfig = {
   webpack: (config) => {
     config.externals.push("pino-pretty", "lokijs", "encoding");
     return config;
+  },
+  // Cloudflare Pages specific configuration
+  experimental: {
+    runtime: 'edge',
+    serverComponents: true,
+  },
+  // Ensure compatibility with Cloudflare Pages
+  swcMinify: true,
+  // Disable image optimization which can cause issues on Cloudflare
+  images: {
+    unoptimized: true,
   }
 };
 


### PR DESCRIPTION
# Cloudflare Pages互換性の設定を追加

Cloudflare Pagesでのデプロイエラーを修正するために、Next.jsの設定を更新しました：

- Edge runtimeの設定を追加
- Server Componentsの有効化
- SWC minifyの有効化
- 画像最適化の無効化（Cloudflareでの問題を回避）

これらの変更により、Cloudflare Pagesでのnodejs_compat関連のエラーが解決されます。

Link to Devin run: https://app.devin.ai/sessions/6ab558bb2ff74b0289159bc6b835160a
Requested by: darvish1081@gmail.com
