### PR TITLE
ヘッダーからreownロゴを削除

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,12 +28,6 @@ export default function Home() {
 
   return (
     <main className="min-h-screen px-8 py-0 pb-12 flex-1 flex flex-col items-center">
-      <header className="w-full py-4 flex justify-between items-center">
-        <div className="flex items-center">
-          <img src="/reown-logo.png" alt="logo" className="w-35 h-10 mr-2" />
-          <div className="hidden sm:inline text-xl font-bold">Reown - AppKit EVM</div>
-        </div>
-      </header>
       <h2 className="my-8 text-2xl font-bold leading-snug text-center">Examples</h2>
       <div className="max-w-4xl">
         <div className="grid bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">


### PR DESCRIPTION
# ヘッダーからreownロゴを削除

ユーザーの要望に従い、アプリケーションのヘッダーからreownロゴを削除しました。これにより、UIがよりシンプルになり、ユーザーエクスペリエンスが向上します。

Link to Devin run: https://app.devin.ai/sessions/6ab558bb2ff74b0289159bc6b835160a
Requested by: darvish1081@gmail.com
