### PR TITLE
ヘッダーからreownロゴを削除

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,20 +42,6 @@ export default function Home() {
 
   return (
     <main className="min-h-screen px-8 py-0 pb-12 flex-1 flex flex-col items-center">
-      {/* ヘッダー */}
-      <header className="w-full py-4 flex justify-between items-center">
-        <div className="flex items-center">
-        <Image
-          src="/reown-logo.png"
-          alt="logo"
-          width={140}
-          height={40}
-          className="mr-2"
-        />
-          <div className="hidden sm:inline text-xl font-bold">Reown - AppKit EVM</div>
-        </div>
-      </header>
-
       <div className="max-w-4xl w-full">
         {/* ウォレット接続 */}
         <div className="grid bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">


### PR DESCRIPTION
# ヘッダーからreownロゴを削除

ユーザーの要望に従い、アプリケーションのヘッダーからreownロゴを削除しました。これにより、UIがよりシンプルになり、ユーザーエクスペリエンスが向上します。

以前のPRでマージコンフリクトが発生したため、最新のmainブランチに基づいて新しいPRを作成しました。

Link to Devin run: https://app.devin.ai/sessions/6ab558bb2ff74b0289159bc6b835160a
Requested by: darvish1081@gmail.com
