### PR TITLE
Ethereum MainnetからSepoliaテストネットへの切り替え機能を追加

### DIFF
--- a/config/index.tsx
+++ b/config/index.tsx
@@ -1,6 +1,7 @@
 import { cookieStorage, createStorage, http } from '@wagmi/core'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain} from '@reown/appkit/networks'
+import { sepolia } from 'viem/chains'
 
 // Get projectId from https://cloud.reown.com
 export const projectId = process.env.NEXT_PUBLIC_PROJECT_ID
@@ -9,7 +10,7 @@ if (!projectId) {
   throw new Error('Project ID is not defined')
 }
 
-export const networks = [mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain]
+export const networks = [mainnet, sepolia, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain]
 
 //Set up the Wagmi Adapter (Config)
 export const wagmiAdapter = new WagmiAdapter({


### PR DESCRIPTION
# Ethereum MainnetからSepoliaテストネットへの切り替え機能を追加

ユーザーの要望に従い、Ethereum MainnetからSepoliaテストネットへの切り替え機能を実装しました。

## 変更内容
- Reown AppKitの設定にSepoliaテストネットを追加
- ネットワーク選択UIを通じてSepoliaテストネットに切り替え可能に

この変更により、開発中にテストネットを使用してアプリケーションをテストできるようになります。

Link to Devin run: https://app.devin.ai/sessions/6ab558bb2ff74b0289159bc6b835160a
Requested by: darvish1081@gmail.com