### PR TITLE
GameCoin残高取得機能をWagmiフックを使用して実装

### DIFF
--- a/contracts/GameCoin.ts
+++ b/contracts/GameCoin.ts
@@ -1,7 +1,7 @@
-import { Address, createPublicClient, http } from 'viem';
+import { Address } from 'viem';
 import { sepolia } from 'viem/chains';
 
-const gameCoinABI = [
+export const gameCoinABI = [
   {
     inputs: [{ name: '', type: 'address' }],
     name: 'gameCoinBalance',
@@ -12,27 +12,6 @@ const gameCoinABI = [
 ] as const;
 
 export const GAME_COIN_ADDRESS = '0x359394D70Ca0565C9F5e85D9182ae62D4bcfE745';
-
-const publicClient = createPublicClient({
-  chain: sepolia,
-  transport: http(),
-});
-
-export async function getGameCoinBalance(userAddress: Address): Promise<bigint> {
-  try {
-    const balance = await publicClient.readContract({
-      address: GAME_COIN_ADDRESS,
-      abi: gameCoinABI,
-      functionName: 'gameCoinBalance',
-      args: [userAddress],
-    });
-    
-    return balance;
-  } catch (error) {
-    console.error('Failed to fetch GameCoin balance:', error);
-    return BigInt(0);
-  }
-}
 
 export function formatGameCoinBalance(balance: bigint): string {
   const decimals = 6; // USDTと同じ小数点以下の桁数を想定


### PR DESCRIPTION
# GameCoin残高取得機能をWagmiフックを使用して実装

ユーザーの要望に従い、GameCoinコントラクトとのインタラクションをWagmiフックを使用するように実装しました。

## 変更内容
1. **Wagmiフックを使用したコントラクト呼び出し**
   - `useContractRead`フックを使用してGameCoinコントラクトの残高を取得するように実装
   - 直接viemを使用していた部分を削除し、Wagmiのフックに置き換え
   - `query.enabled`オプションを使用して、適切な条件下でのみコントラクト呼び出しが行われるように設定

2. **GameCoin.tsファイルの簡素化**
   - 直接viemを使用していた部分を削除
   - ABIとコントラクトアドレスのエクスポートのみに変更
   - フォーマット関数は残して再利用

これらの変更により、既存のWagmiインフラストラクチャを活用してGameCoinコントラクトとインタラクションできるようになりました。

Link to Devin run: https://app.devin.ai/sessions/6ab558bb2ff74b0289159bc6b835160a
Requested by: darvish1081@gmail.com