### PR TITLE
GameCoinコントラクトの書き込み機能を実装

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import { useAccount, useChainId, useSwitchChain, useContractRead } from "wagmi";
 import TokenList from "@/components/TokenList";
 import SendModal from "@/components/SendModal";
+import GameCoinActions from "@/components/GameCoinActions";
 import Image from "next/image";
 import { sepolia } from "viem/chains";
 import { GAME_COIN_ADDRESS, gameCoinABI, formatGameCoinBalance } from "@/contracts/GameCoin";
@@ -176,6 +177,12 @@ export default function Home() {
                       <span>GameCoin残高: {gameCoinBalance} BCM</span>
                     </div>
                     <h2 className="text-xl font-bold mb-4">Game Tokens</h2>
+                    
+                    {/* GameCoin操作UI */}
+                    <div className="mb-6">
+                      <GameCoinActions />
+                    </div>
+                    
                     <div className="grid grid-cols-2 gap-4">
                       {/* NFTのプレースホルダー */}
                       {[1, 2, 3, 4].map((item) => (

--- a/components/GameCoinActions.tsx
+++ b/components/GameCoinActions.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import React, { useState } from 'react';
+import { useDepositAndApproveUSDT, useUseGameCoin } from '../hooks/useGameCoin';
+
+export default function GameCoinActions() {
+  const [amount, setAmount] = useState('1000000'); // 単位：最小単位（例：6桁 = 1.0）
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  
+  const { depositAndApproveUSDT, isPending: isDepositPending, isSuccess: isDepositSuccess } = useDepositAndApproveUSDT();
+  const { useGameCoin, isPending: isUsePending, isSuccess: isUseSuccess } = useUseGameCoin();
+
+  const handleDeposit = async () => {
+    try {
+      setError('');
+      setSuccessMessage('');
+      await depositAndApproveUSDT(BigInt(amount));
+      setSuccessMessage('USDTの入金とGameCoinの発行に成功しました！');
+    } catch (err: any) {
+      setError(err.message || 'USDTの入金に失敗しました');
+    }
+  };
+
+  const handleUse = async () => {
+    try {
+      setError('');
+      setSuccessMessage('');
+      await useGameCoin(BigInt(amount));
+      setSuccessMessage('GameCoinの使用に成功しました！');
+    } catch (err: any) {
+      setError(err.message || 'GameCoinの使用に失敗しました');
+    }
+  };
+
+  return (
+    <div className="mt-6 space-y-4">
+      <h2 className="text-xl font-bold mb-4">GameCoin操作</h2>
+      
+      <div className="mb-4">
+        <label className="block text-sm font-medium text-gray-700 mb-1">数量（最小単位）</label>
+        <div className="flex">
+          <input
+            type="text"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="flex-1 p-2 border rounded-l"
+            placeholder="1000000 = 1.0 GameCoin"
+          />
+          <button
+            onClick={() => setAmount('1000000')}
+            className="bg-gray-200 px-3 py-2 rounded-r text-sm"
+          >
+            1.0
+          </button>
+        </div>
+        <p className="text-xs text-gray-500 mt-1">1,000,000 = 1.0 GameCoin（6桁精度）</p>
+      </div>
+      
+      <div className="grid grid-cols-2 gap-4">
+        <button
+          onClick={handleDeposit}
+          disabled={isDepositPending}
+          className="bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded-lg font-medium"
+        >
+          {isDepositPending ? '処理中...' : 'USDT入金'}
+        </button>
+        
+        <button
+          onClick={handleUse}
+          disabled={isUsePending}
+          className="bg-red-500 hover:bg-red-600 text-white py-2 px-4 rounded-lg font-medium"
+        >
+          {isUsePending ? '処理中...' : 'GameCoin使用'}
+        </button>
+      </div>
+      
+      {error && (
+        <div className="p-3 bg-red-100 text-red-800 rounded-lg mt-4">
+          <p className="font-medium">エラー</p>
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
+      
+      {successMessage && (
+        <div className="p-3 bg-green-100 text-green-800 rounded-lg mt-4">
+          <p className="font-medium">成功</p>
+          <p className="text-sm">{successMessage}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/contracts/GameCoin.ts
+++ b/contracts/GameCoin.ts
@@ -9,6 +9,20 @@ export const gameCoinABI = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [{ internalType: 'uint256', name: 'amount', type: 'uint256' }],
+    name: 'depositAndApproveUSDT',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'amount', type: 'uint256' }],
+    name: 'useGameCoin',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
 ] as const;
 
 export const GAME_COIN_ADDRESS = '0x359394D70Ca0565C9F5e85D9182ae62D4bcfE745';

--- a/hooks/useGameCoin.ts
+++ b/hooks/useGameCoin.ts
@@ -1,0 +1,35 @@
+import { useWriteContract } from 'wagmi';
+import { GAME_COIN_ADDRESS, gameCoinABI } from '../contracts/GameCoin';
+import { sepolia } from 'viem/chains';
+
+export function useDepositAndApproveUSDT() {
+  const { writeContractAsync, isPending, isSuccess, error } = useWriteContract();
+  
+  const depositAndApproveUSDT = async (amount: bigint) => {
+    return writeContractAsync({
+      address: GAME_COIN_ADDRESS as `0x${string}`,
+      abi: gameCoinABI,
+      functionName: 'depositAndApproveUSDT',
+      args: [amount],
+      chainId: sepolia.id,
+    });
+  };
+  
+  return { depositAndApproveUSDT, isPending, isSuccess, error };
+}
+
+export function useUseGameCoin() {
+  const { writeContractAsync, isPending, isSuccess, error } = useWriteContract();
+  
+  const useGameCoin = async (amount: bigint) => {
+    return writeContractAsync({
+      address: GAME_COIN_ADDRESS as `0x${string}`,
+      abi: gameCoinABI,
+      functionName: 'useGameCoin',
+      args: [amount],
+      chainId: sepolia.id,
+    });
+  };
+  
+  return { useGameCoin, isPending, isSuccess, error };
+}


### PR DESCRIPTION
# GameCoin残高取得機能をWagmiフックを使用して実装

ユーザーの要望に従い、GameCoinコントラクトとのインタラクションをWagmiフックを使用するように実装しました。

## 変更内容
1. **Wagmiフックを使用したコントラクト呼び出し**
   - `useContractRead`フックを使用してGameCoinコントラクトの残高を取得するように実装
   - 直接viemを使用していた部分を削除し、Wagmiのフックに置き換え
   - `query.enabled`オプションを使用して、適切な条件下でのみコントラクト呼び出しが行われるように設定

2. **GameCoin.tsファイルの簡素化**
   - 直接viemを使用していた部分を削除
   - ABIとコントラクトアドレスのエクスポートのみに変更
   - フォーマット関数は残して再利用

これらの変更により、既存のWagmiインフラストラクチャを活用してGameCoinコントラクトとインタラクションできるようになりました。

Link to Devin run: https://app.devin.ai/sessions/6ab558bb2ff74b0289159bc6b835160a
Requested by: darvish1081@gmail.com
