### PR TITLE
Sepoliaテストネットをデフォルトネットワークとして設定

### DIFF
--- a/config/index.tsx
+++ b/config/index.tsx
@@ -1,7 +1,7 @@
 import { cookieStorage, createStorage, http } from '@wagmi/core'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain} from '@reown/appkit/networks'
-import { sepolia } from 'viem/chains'
+import { sepolia } from '@reown/appkit/networks'
 
 // Get projectId from https://cloud.reown.com
 export const projectId = process.env.NEXT_PUBLIC_PROJECT_ID
@@ -10,7 +10,7 @@ if (!projectId) {
   throw new Error('Project ID is not defined')
 }
 
-export const networks = [mainnet, sepolia, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain]
+export const networks = [sepolia, mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain]
 
 const combinedStorage = createStorage({
   storage: {

--- a/context/index.tsx
+++ b/context/index.tsx
@@ -2,7 +2,7 @@
 
 import { wagmiAdapter, projectId } from '@/config'
 import { createAppKit } from '@reown/appkit/react' 
-import { mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain} from '@reown/appkit/networks'
+import { mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain, sepolia} from '@reown/appkit/networks'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React, { type ReactNode, useEffect } from 'react'
@@ -51,10 +51,11 @@ const modal = createAppKit({
     48900: '/zircuit.svg',
     11_124: '/abstract.png',
     30: '/rootstock.png',
+    11155111: '/images/tokens/eth.png', // Sepolia
   },
   projectId,
-  networks: [mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain],
-  defaultNetwork: mainnet,
+  networks: [sepolia, mainnet, arbitrum, scroll, morph, berachainTestnetbArtio, mantle, soneium, zircuit, rootstock, abstract, viction, monadTestnet, celo, apeChain],
+  defaultNetwork: sepolia,
   metadata: metadata,
   features: {
     analytics: true, // Optional - defaults to your Cloud configuration


### PR DESCRIPTION
# Sepoliaテストネットをデフォルトネットワークとして設定

ユーザーの要望に従い、Sepoliaテストネットをデフォルトネットワークとして設定し、アプリケーションの起動時に自動的に接続するように実装しました。

## 変更内容

1. **Sepoliaネットワークの設定**
   - `config/index.tsx`と`context/index.tsx`でSepoliaをデフォルトネットワークとして設定
   - ネットワークリストの先頭にSepoliaを配置し、優先的に表示されるように変更

2. **Wagmiの使用**
   - Viemの代わりにReownのネットワーク設定を使用
   - `import { sepolia } from 'viem/chains'`を`import { sepolia } from '@reown/appkit/networks'`に変更

3. **Sepoliaアイコンの追加**
   - Sepoliaネットワークのアイコンを設定

これらの変更により、アプリケーションを開くと自動的にSepoliaテストネットに接続されるようになります。

Link to Devin run: https://app.devin.ai/sessions/6ab558bb2ff74b0289159bc6b835160a
Requested by: darvish1081@gmail.com
